### PR TITLE
Fix "Could not find or access"

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: BSD
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.2
 
   platforms:
   - name: Fedora

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
     src: "{{ rust_dir }}/{{ rust_archive_name }}"
     dest: "{{ rust_dir }}"
     creates: "{{ rust_archive_unpack_done }}"
+    remote_src: yes
 
 - stat: "path={{ rust_archive_unpack_done }}"
   register: x

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,8 @@
     src: "{{ rust_dir }}/{{ rust_std_archive_name }}"
     dest: "{{ rust_dir }}"
     creates: "{{ rust_std_archive_unpack_done }}"
-
+    remote_src: yes
+    
 - stat: "path={{ rust_std_archive_unpack_done }}"
   register: x
 


### PR DESCRIPTION
```
TASK [rust : Unarchive Rust] *******************************************************************************************************************************************************************
fatal: [79.133.48.245]: FAILED! => {"changed": false, "msg": "Could not find or access '/opt/rust/rust-1.23.0-x86_64-unknown-linux-gnu.tar.gz'"}
        to retry, use: --limit @/home/gdr/src/.../worker.retry
```

The reason is:

https://stackoverflow.com/questions/32698529/ansible-unarchive-input-file-not-found#32702447